### PR TITLE
Error with array indexing fixed

### DIFF
--- a/src/calendar-tile.js
+++ b/src/calendar-tile.js
@@ -4,13 +4,13 @@ import './calendar-tile.css'
 
 // A list of the days of the week, so that we can tell the user that rather than the date (easier to read)
 const DAYS_OF_WEEK = [
+	'Sunday',
 	'Monday',
 	'Tuesday',
 	'Wednesday',
 	'Thursday',
 	'Friday',
-	'Saturday',
-	'Sunday'
+	'Saturday'
 	]
 
 class CalendarTile extends Component {
@@ -49,7 +49,7 @@ class CalendarTile extends Component {
 		const overOneWeek = this.isOverOneWeek(startMoment)
 
 		this.setState({
-			startDate: !overOneWeek ? DAYS_OF_WEEK[startMoment.day()+1] : startMoment.format('MMM Do'),
+			startDate: !overOneWeek ? DAYS_OF_WEEK[startMoment.day()] : startMoment.format('MMM Do'),
 			endDate: DAYS_OF_WEEK[startMoment.day()],
 			startTime: `${startMoment.format('h:mmA')}`,
 			endTime: `${endMoment.format('h:mmA')}`,

--- a/src/calendar-tile.js
+++ b/src/calendar-tile.js
@@ -49,7 +49,7 @@ class CalendarTile extends Component {
 		const overOneWeek = this.isOverOneWeek(startMoment)
 
 		this.setState({
-			startDate: !overOneWeek ? DAYS_OF_WEEK[startMoment.day()] : startMoment.format('MMM Do'),
+			startDate: !overOneWeek ? DAYS_OF_WEEK[startMoment.day()+1] : startMoment.format('MMM Do'),
 			endDate: DAYS_OF_WEEK[startMoment.day()],
 			startTime: `${startMoment.format('h:mmA')}`,
 			endTime: `${endMoment.format('h:mmA')}`,


### PR DESCRIPTION
The array for days of the week within calendar-tile.js begins with Monday at 0. If the event info that the calendar draws from indexes with Monday at 1, the days would be rendered incorrectly here. If the error is fixed at the source, the change is unnecessary. Unsure whether this is the case, but it's my best guess.